### PR TITLE
use version number instead of release in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.5
   - nightly
 notifications:
   email: false


### PR DESCRIPTION
`release` will change over time, but since the package supports julia 0.5
according to REQUIRE, it should continue to be tested there

would be good to enable this at https://travis-ci.org/tkluck/StatProfilerHTML.jl