### PR TITLE
Use perl from PATH, not hard coded

### DIFF
--- a/bin/statprofilehtml
+++ b/bin/statprofilehtml
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/bin/env perl
 # PODNAME: statprofilehtml
 # ABSTRACT: generate Devel::StatProfiler HTML report
 


### PR DESCRIPTION
This should work for more users who may have an old Perl version in /usr/bin but have installed another one somewhere else.