### PR TITLE
Add a kwarg to include C functions in output.

### DIFF
--- a/src/StatProfilerHTML.jl
+++ b/src/StatProfilerHTML.jl
@@ -19,7 +19,7 @@ const statprofilehtml_pl = joinpath(basepath, "bin", "statprofilehtml.pl")
 const perllib            = joinpath(basepath, "perllib")
 
 function statprofilehtml(data::Array{UInt,1} = UInt[],litrace::Dict{UInt,Array{StackFrame,1}} = Dict{UInt,Array{StackFrame,1}}();
-                         C=false)
+                         from_c=false)
     if length(data) == 0
         (data, litrace) = Profile.retrieve()
     end
@@ -39,7 +39,7 @@ function statprofilehtml(data::Array{UInt,1} = UInt[],litrace::Dict{UInt,Array{S
                 # all of them
                 frames= litrace[d]
                 for frame in frames
-                  if !frame.from_c || C 
+                  if !frame.from_c || from_c
                         file = Base.find_source_file(string(frame.file))
                         func_line = frame.line
                         with_value(frame.linfo) do linfo

--- a/src/StatProfilerHTML.jl
+++ b/src/StatProfilerHTML.jl
@@ -18,7 +18,8 @@ const sharepath          = joinpath(basepath, "share")
 const statprofilehtml_pl = joinpath(basepath, "bin", "statprofilehtml.pl")
 const perllib            = joinpath(basepath, "perllib")
 
-function statprofilehtml(data::Array{UInt,1} = UInt[],litrace::Dict{UInt,Array{StackFrame,1}} = Dict{UInt,Array{StackFrame,1}}())
+function statprofilehtml(data::Array{UInt,1} = UInt[],litrace::Dict{UInt,Array{StackFrame,1}} = Dict{UInt,Array{StackFrame,1}}();
+                         C=false)
     if length(data) == 0
         (data, litrace) = Profile.retrieve()
     end
@@ -38,7 +39,7 @@ function statprofilehtml(data::Array{UInt,1} = UInt[],litrace::Dict{UInt,Array{S
                 # all of them
                 frames= litrace[d]
                 for frame in frames
-                    if !frame.from_c
+                  if !frame.from_c || C 
                         file = Base.find_source_file(string(frame.file))
                         func_line = frame.line
                         with_value(frame.linfo) do linfo

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,3 +20,15 @@ fibonacci(n) = n <= 2 ? 1 : fibonacci(n-1) + fibonacci(n-2)
         end
     end
 end
+
+@testset "C functions" begin
+    mktempdir() do dir
+        cd(dir) do
+            @profile fibonacci(43)
+
+            statprofilehtml(C=true)
+
+            @test isdir("statprof")
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,7 +26,7 @@ end
         cd(dir) do
             @profile fibonacci(43)
 
-            statprofilehtml(C=true)
+            statprofilehtml(from_c=true)
 
             @test isdir("statprof")
         end


### PR DESCRIPTION
Hi!

This package is really nice, thanks for putting it together! So far, it's my favorite of all the profiling solutions I've found. :)

The one thing it's missing for us that we really need is information about the C functions in the profile as well.

In this PR I made the simple change of just allowing C functions with a `C` keyword argument. (That name seems kind of terrible, but I was following the convention in `Profile.print` ([docs](https://docs.julialang.org/en/v1/manual/profile/index.html#Options-for-controlling-the-display-of-profile-results-1)) but we can definitely change it if you don't like it.)

However -- and I'm sure this is the reason you excluded C functions in the first place:
 - Clicking on a C function in the HTML viewer seems to usually return a 404. It seems that it's not generating the necessary pages for C functions for some reason?

Is that something you think we could easily fix? Maybe, if not, we could just disable the links?
That said, even without viewing the source on those functions, having the C functions included in the flame graph is still really helpful! So this seems worth it to me even if we can't get the links to work. :)