### PR TITLE
Translate build bot directory to local source

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,3 +19,10 @@ DataStructures = "0.17, 0.18"
 FlameGraphs = "0.1, 0.2"
 HAML = "0.3.1"
 julia = "1.6"
+
+[extras]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Random", "Test"]

--- a/src/Reports.jl
+++ b/src/Reports.jl
@@ -20,9 +20,17 @@ end
 
 const found_source_files = Dict{Symbol, Union{Nothing, Symbol}}()
 
+function find_source_file(file)
+    res = Base.find_source_file(file)
+    !isnothing(res) && isfile(res) && return res
+    # try to translate build bot directory to local source
+    res = replace(file, r".*?[\\/]usr[\\/]share[\\/]julia[\\/]stdlib" => joinpath(Sys.BINDIR, Base.DATAROOTDIR, "julia", "stdlib"))
+    isfile(res) ? normpath(res) : nothing
+end
+
 TracePoint(frame::StackFrame) = begin
     file = get!(found_source_files, frame.file) do
-        res = Base.find_source_file(string(frame.file))
+        res = find_source_file(string(frame.file))
         isnothing(res) ? nothing : Symbol(res)
     end
 

--- a/test/end-to-end.jl
+++ b/test/end-to-end.jl
@@ -47,4 +47,22 @@ fibonacci(n) = n <= 2 ? 1 : fibonacci(n-1) + fibonacci(n-2)
             end
         end
     end
+
+    function searchdir(dir, pat)
+        any(readdir(dir)) do path
+            !isnothing(match(pat, path))
+        end
+    end
+
+    @testset "Translate stdlib path" begin
+        mktempdir() do dir
+            cd(dir) do
+                a = Vector{UInt8}(undef, 10000000)
+                @profilehtml rand!(a, [1, 2, 3])
+
+                @test isdir("statprof")
+                @test searchdir("statprof", r"generation\.jl-.+")
+            end
+        end
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using StatProfilerHTML
+using Random
 
 using Test
 using Profile


### PR DESCRIPTION
Files from stdlib retain their path on the build bot, which can not be located on the local machine. 

This patch tries to locate these file on user's local julia directory as a fallback in case `Base.find_source_file` can not find them. Since these files were ignored before, including them in the report will be a net gain.